### PR TITLE
[#118913773] Fix Showing Transactions#index

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class TransactionsController < ApplicationController
       before_action :set_transaction, only: [:show, :update, :destroy]
+      before_action :set_transactions, only: [:index]
       before_action :authenticate_with_token
       respond_to :json
 
@@ -12,7 +13,7 @@ module Api
       def index
         page = params[:page].to_i > 0 ? params[:page].to_i : 1
         limit = params[:limit].to_i > 0 ? params[:limit].to_i : 20
-        @transactions = current_user.transactions.paginate(page, limit)
+        @transactions = @transactions.paginate(page, limit)
         render json: @transactions, meta: {
           total: current_user.transactions.count,
           current: page
@@ -47,6 +48,17 @@ module Api
 
       def set_transaction
         @transaction ||= Transaction.find(params[:id])
+      end
+
+      def set_transactions
+        if params[:customer_id]
+          return @transactions = Transaction.where(
+            customer_id: params[:customer_id],
+            user_id: current_user.id
+          )
+        else
+          return @transactions = Transaction.where(user_id: current_user.id)
+        end
       end
 
       def transaction_params

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 99.05
+    "covered_percent": 98.92
   }
 }

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -1216,6 +1216,7 @@
         1,
         1,
         1,
+        1,
         null,
         1,
         2,
@@ -1259,6 +1260,17 @@
         null,
         1,
         10,
+        null,
+        null,
+        1,
+        7,
+        0,
+        null,
+        null,
+        null,
+        null,
+        7,
+        null,
         null,
         null,
         1,
@@ -1629,6 +1641,6 @@
         null
       ]
     },
-    "timestamp": 1462359202
+    "timestamp": 1462362902
   }
 }


### PR DESCRIPTION
Transactions#index was displaying all user's trasactions even when a customer is specified
This pull request resolves the above problem
Now when no customer_id is specified, all the user's transactions are displayed
When a customer_id is specified, only the customer's transactions are displayed
